### PR TITLE
add a Fortran wrapper for DNS simulation

### DIFF
--- a/dns_libis.cpp
+++ b/dns_libis.cpp
@@ -1,0 +1,110 @@
+#include "dns_libis.h"
+
+#include <stdio.h>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include "mpi.h"
+
+#include "libIS/is_sim.h"
+
+static libISSimState* libis_state;
+
+void libis_send(double* udata, int* nx32, int* ny, int* nz32) {
+#if 0  // dump raw data
+    static int tstep = 0;
+    int rank;
+    MPI_Comm sim_comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(sim_comm, &rank);
+
+    int xsize = *nx32;
+    int ysize = *ny;
+    int zsize = *nz32;
+
+    std::string name = "dns-rank" + std::to_string(rank) + "-t" +
+                       std::to_string(tstep) + ".raw";
+    FILE* fp = fopen(name.c_str(), "wb");
+    if (fp) {
+      fwrite(udata, sizeof(double), xsize * ysize * zsize, fp);
+      fclose(fp);
+    }
+    ++tstep;
+#endif
+  libISProcess(libis_state);
+}
+
+void libis_initialize(double* udata, int* nx32, int* ny, int* nz32, int* Xyst,
+                      int* Xysz, int* Xzst, int* Xzsz, double* LMFx,
+                      double* LMFy, double* LMFz) {
+  // NOTE: volume size should be (x,y,z) = (8pi, 2, 3pi)
+  double world_size_x = *LMFx * 2.0 * M_PI * 1000;
+  double world_size_y = *LMFy * 2.0 * 1000;
+  double world_size_z = *LMFz * 2.0 * M_PI * 1000;
+
+  double spacing_x = world_size_x / (*nx32);
+  // TODO spacinngs vary along y-axis, use constant factor for now
+  double spacing_y = world_size_y / (*ny);
+  double spacing_z = world_size_z / (*nz32);
+
+  double world_begin_x = 0.0;
+  double world_begin_y = 0.0;
+  double world_begin_z = 0.0;
+
+  double world_end_x = world_size_x;
+  double world_end_y = world_size_y;
+  double world_end_z = world_size_z;
+
+  double local_begin_x = world_begin_x;
+  double local_begin_y = spacing_y * (*Xyst);
+  double local_begin_z = spacing_z * (*Xzst);
+
+  double local_end_x = world_end_x;
+  double local_end_y = local_begin_y + (spacing_y * (*Xysz));
+  double local_end_z = local_begin_z + (spacing_z * (*Xzsz));
+
+  libISInit(MPI_COMM_WORLD, 29374);
+
+  libis_state = libISMakeSimState();
+
+  libISVec3f world_min{world_begin_x, world_begin_y, world_begin_z};
+  libISVec3f world_max{world_end_x, world_end_y, world_end_z};
+
+  libISBox3f world_bounds = libISMakeBox3f();
+  libISBoxExtend(&world_bounds, &world_min);
+  libISBoxExtend(&world_bounds, &world_max);
+  libISSetWorldBounds(libis_state, world_bounds);
+
+  libISVec3f local_min{local_begin_x, local_begin_y, local_begin_z};
+  libISVec3f local_max{local_end_x, local_end_y, local_end_z};
+
+  libISBox3f local_bounds = libISMakeBox3f();
+  libISBoxExtend(&local_bounds, &local_min);
+  libISBoxExtend(&local_bounds, &local_max);
+  libISSetLocalBounds(libis_state, local_bounds);
+  // libISSetGhostBounds(libis_state, ghost_bounds);
+  //
+  const uint64_t dimensions[3] = {*nx32, *Xysz, *Xzsz};
+  libISSetField(libis_state, "field_u", dimensions, DOUBLE, udata);
+
+#if 0  // dump size info
+    int rank;
+    MPI_Comm sim_comm = MPI_COMM_WORLD;
+    MPI_Comm_rank(sim_comm, &rank);
+
+    std::string name_size = "dns-rank" + std::to_string(rank) + ".size";
+    FILE* fp_size = fopen(name_size.c_str(), "wt");
+    if (fp_size) {
+      fprintf(fp_size, "%d %d %d %f %f %f %f %f %f", dimensions[0],
+              dimensions[1], dimensions[2], local_min.x, local_min.y,
+              local_min.z, local_max.x, local_max.y, local_max.z);
+      fclose(fp_size);
+    }
+#endif
+}
+
+void libis_finalize() {
+  libISFreeSimState(libis_state);
+  libISFinalize();
+}
+

--- a/dns_libis.f90
+++ b/dns_libis.f90
@@ -1,0 +1,33 @@
+module dns_libis
+  use,intrinsic :: iso_c_binding
+  implicit none
+
+  interface
+    subroutine libis_send(udata, nx32, ny, nz32) bind(C, name="libis_send")
+      use,intrinsic :: iso_c_binding
+      implicit none
+      real(c_double) :: udata(nx32, ny, nz32)
+      integer(c_intptr_t) :: nx32, ny, nz32
+    end subroutine libis_send
+  end interface
+
+  interface
+    subroutine libis_initialize(udata, nx32, ny, nz32, Xyst, Xysz, Xzst, Xzsz, LMFx, LMFy, LMFz) bind(C, name="libis_initialize")
+      use,intrinsic :: iso_c_binding
+      implicit none
+      integer(c_intptr_t) :: nx32, ny, nz32
+      integer(c_intptr_t) :: Xyst, Xysz, Xzst, Xzsz
+      real(c_double) :: LMFx, LMFy, LMFz
+      real(c_double) :: udata(nx32, Xysz, Xzsz)
+    end subroutine libis_initialize
+  end interface
+
+  interface
+    subroutine libis_finalize() bind(C, name="libis_finalize")
+      use,intrinsic :: iso_c_binding
+      implicit none
+    end subroutine libis_finalize
+  end interface
+
+end module dns_libis
+

--- a/dns_libis.h
+++ b/dns_libis.h
@@ -1,0 +1,39 @@
+#ifndef DNS_LIBIS_H_
+#define DNS_LIBIS_H_
+
+extern "C" {
+
+/**
+ * Configure libIS.
+ * \param udata An 1D array containing 3D volume data organized in xyz order.
+ * \param nx32 Numer of voxels in x direction.
+ * \param ny Number of voxels in y direction.
+ * \param nz32 Number of voxels in z direction.
+ * \param Xyst An index value of the first voxel along the y-axis for an
+ * x-pencil sub-volume. \param Xysz Number of volxels along the y-axis for an
+ * x-pencil sub-volume. \param Xzst An index value of the first voxel along the
+ * z-axis for an x-pencil sub-volume. \param Xzsz Number of volxels along the
+ * z-axis for an x-pencil sub-volume. \param LMFx A user-defined volume
+ * stretching factor in x direction. \param LMFy A user-defined volume
+ * stretching factor in y direction. \param LMFz A user-defined volume
+ * stretching factor in z direction.
+ */
+void libis_initialize(double* udata, int* nx32, int* ny, int* nz32, int* Xyst,
+                      int* Xysz, int* Xzst, int* Xzsz, double* LMFx,
+                      double* LMFy, double* LMFz);
+/**
+ * Send assigned volume data.
+ * \param udata An 1D array containing 3D volume data organized in xyz order.
+ * \param nx32 Numer of voxels in x direction.
+ * \param ny Number of voxels in y direction.
+ * \param nz32 Number of voxels in z direction.
+ */
+void libis_send(double* udata, int* nx32, int* ny, int* nz32);
+
+/**
+ * Free libIS simulation state disconnect form libIS.
+ */
+void libis_finalize();
+}
+
+#endif


### PR DESCRIPTION
The wrapper contains the following interfaces:
  libis_initialize: to configure libIS
  libis_send: to send an 1D array of 3D volume data to libIS clients
  libis_finalize: to disconnect from libIS